### PR TITLE
Iss23

### DIFF
--- a/src/Margay.cpp
+++ b/src/Margay.cpp
@@ -348,7 +348,7 @@ int Margay::begin(String header_)
 
 void Margay::I2Ctest()
 {
-	bool initialStateI2C = digitalRead(I2C_SW);
+	bool initialStateExternalI2C = digitalRead(I2C_SW);
 
 	switchExternalI2C(ON);
 	
@@ -386,7 +386,7 @@ void Margay::I2Ctest()
 	if(I2C_Test) Serial.println("PASS");
 
 	// make sure I2C Bus is returned to initial state
-	closeFarmGateI2C(initialStateI2C);
+	farmGateI2C(initialStateExternalI2C);
 }
 
 
@@ -734,7 +734,8 @@ float Margay::getVoltage()  //Get voltage from Ax pin
 	// bus communication by taking a voltage reading. So we have logic here to make the switch.
 
 	// first check whether external I2C connnections are on by testing pin I2C_SW (HIGH is on)
-	bool initialStateI2C = digitalRead(I2C_SW);
+	// When the external I2C connection is on, the internal I2C connection is cut off.
+	bool initialStateExternalI2C = digitalRead(I2C_SW);
 
 	// initialize a variable to hold the voltage reading.
 	float val = 0;
@@ -742,10 +743,9 @@ float Margay::getVoltage()  //Get voltage from Ax pin
 	switchExternalI2C(OFF);
 	initADC(18); // initialize ADC
 	val = adc.GetVoltage();
-	switchExternalI2C(ON); // re-allow external I2C		
 
 	// make sure I2C Bus is returned to initial state
-	closeFarmGateI2C(initialStateI2C);
+	farmGateI2C(initialStateExternalI2C);
 
 	return val;
 }
@@ -836,7 +836,7 @@ void Margay::switchExternalI2C(bool desiredState)
 	delay(1); // Any time needed to switch states; may not be necessary
 }
 
-void Margay::closeFarmGateI2C(bool initStateI2C)
+void Margay::farmGateI2C(bool initStateI2C)
 {
 	// This closes the farm gate at the end of a function that uses external I2C bus. 
 	// It works by by checking if the current state of I2C Comms (class variable)
@@ -856,14 +856,13 @@ void Margay::addDataPoint(String (*update)(void)) //Reads new data and writes da
 	if(Model >= MODEL_2v0) EnviroSense.begin(0x77); //Re-initialize BME280  //FIX??
 	// Serial.println("Called Update"); //DEBUG!
 	
-	bool initialStateI2C = digitalRead(I2C_SW);
+	bool initialStateExternalI2C = digitalRead(I2C_SW);
 
 	switchExternalI2C(ON);
 	data = (*update)(); //Run external update function	
-	switchExternalI2C(OFF);
 
 	// make sure I2C Bus is returned to initial state
-	closeFarmGateI2C(initialStateI2C);
+	farmGateI2C(initialStateExternalI2C);
 
 	_addDataPoint(data);
 

--- a/src/Margay.cpp
+++ b/src/Margay.cpp
@@ -196,8 +196,7 @@ int Margay::begin(uint8_t *Vals, uint8_t numVals, String header_)
 	// NumADR_OB = 2; //DEBUG!
 	RTC.begin(); //Initalize RTC
 	RTC.clearAlarm(); //
-	adc.Begin(I2C_ADR_OB[1]); //Initalize external ADC
-	adc.SetResolution(18);
+	initADC();
 	EnviroSense.begin(0x77); //Initalize onboard temp/pressure/RH sensor (BME280)
 
 
@@ -897,6 +896,14 @@ void Margay::dateTimeSD(uint16_t* date, uint16_t* time)
 
 	// return time using FAT_TIME macro to format fields
 	*time = FAT_TIME(selfPointer->RTC.getValue(3), selfPointer->RTC.getValue(4), selfPointer->RTC.getValue(5));
+}
+
+void Margay::initADC() 
+{
+	// Serial.print("ADC should be on"); // DEBUG
+	adc.Begin(I2C_ADR_OB[1]); //Initalize external ADC
+	adc.SetResolution(18);
+	delay(250); // allow ADC to spin up and achieve full resolution.
 }
 
 void Margay::dateTimeSD_Glob(uint16_t* date, uint16_t* time) {selfPointer->dateTimeSD(date, time);}  //Fix dumb name!

--- a/src/Margay.cpp
+++ b/src/Margay.cpp
@@ -715,8 +715,22 @@ void Margay::blinkGood()
 
 float Margay::getVoltage()  //Get voltage from Ax pin
 {
-	float val = adc.GetVoltage();
-	return val;
+	// first allow access to ADC via internal I2C
+	pinMode(I2C_SW, INPUT);
+	bool extI2COn = digitalRead(SD_CD);
+
+	if ( !extI2COn ){
+		initADC(); // initialize ADC
+		float val = adc.GetVoltage();
+		return val;
+	}
+	else{
+		externalI2C(OFF);
+		initADC(); // initialize ADC
+		float val = adc.GetVoltage();
+		externalI2C(ON); // re-allow external I2C		
+		return val;
+	}
 }
 
 void Margay::run(String (*update)(void), unsigned long logInterval) //Pass in function which returns string of data
@@ -903,7 +917,7 @@ void Margay::initADC()
 	// Serial.print("ADC should be on"); // DEBUG
 	adc.Begin(I2C_ADR_OB[1]); //Initalize external ADC
 	adc.SetResolution(18);
-	delay(250); // allow ADC to spin up and achieve full resolution.
+	delay(500); // allow ADC to spin up and achieve full resolution.
 }
 
 void Margay::dateTimeSD_Glob(uint16_t* date, uint16_t* time) {selfPointer->dateTimeSD(date, time);}  //Fix dumb name!

--- a/src/Margay.cpp
+++ b/src/Margay.cpp
@@ -348,7 +348,10 @@ int Margay::begin(String header_)
 
 void Margay::I2Ctest()
 {
-	externalI2C(ON);
+	bool initialStateI2C = digitalRead(I2C_SW);
+
+	switchExternalI2C(ON);
+	
 	int Error = 0;
 	bool I2C_Test = true;
 
@@ -366,7 +369,7 @@ void Margay::I2Ctest()
 	}
 
 	//Switch to connect to onboard I2C!
-	externalI2C(OFF);
+	switchExternalI2C(OFF);
 
 	for(int i = 0; i < NumADR_OB; i++) {
 		Wire.beginTransmission(I2C_ADR_OB[i]);
@@ -381,6 +384,9 @@ void Margay::I2Ctest()
 	}
 
 	if(I2C_Test) Serial.println("PASS");
+
+	// make sure I2C Bus is returned to initial state
+	closeFarmGateI2C(initialStateI2C);
 }
 
 
@@ -720,24 +726,19 @@ float Margay::getVoltage()  //Get voltage from Ax pin
 	// bus communication by taking a voltage reading. So we have logic here to make the switch.
 
 	// first check whether external I2C connnections are on by testing pin I2C_SW (HIGH is on)
-	pinMode(I2C_SW, INPUT);
-	bool extI2COn = digitalRead(I2C_SW);
+	bool initialStateI2C = digitalRead(I2C_SW);
 
 	// initialize a variable to hold the voltage reading.
 	float val = 0;
 
-	// if it is off, then we can communicate with ADC already, then take a reading.
-	if ( !extI2COn ){
-		initADC(); // initialize ADC
-		val = adc.GetVoltage();
-	}
-	// otherwise, turn off external I2C comms, take a reading, then turn comms back on.
-	else{
-		externalI2C(OFF);
-		initADC(); // initialize ADC
-		val = adc.GetVoltage();
-		externalI2C(ON); // re-allow external I2C		
-	}
+	switchExternalI2C(OFF);
+	initADC(18); // initialize ADC
+	val = adc.GetVoltage();
+	switchExternalI2C(ON); // re-allow external I2C		
+
+	// make sure I2C Bus is returned to initial state
+	closeFarmGateI2C(initialStateI2C);
+
 	return val;
 }
 
@@ -808,20 +809,37 @@ void Margay::resetWDT()  //Send a pulse to "feed" the watchdog timer
 	digitalWrite(WDHold, LOW);
 }
 
-void Margay::externalI2C(bool state)
+void Margay::switchExternalI2C(bool desiredState)
 {
 	/*
 	Must be ON to read off-board sensors, OFF to read on-board sensors and RTC
 	Serves to isolate these s.t. I2C addresses may not clash.
 	*/
 	pinMode(I2C_SW, OUTPUT);
-	if ( state == ON ){
+
+	if ( desiredState == ON ) {
 		digitalWrite(I2C_SW, HIGH);
+		externalI2COn = digitalRead(I2C_SW);
 	}
-	else{
+	else {
 		digitalWrite(I2C_SW, LOW);
+		externalI2COn = digitalRead(I2C_SW);
 	}
 	delay(1); // Any time needed to switch states; may not be necessary
+}
+
+void Margay::closeFarmGateI2C(bool initStateI2C)
+{
+	// This closes the farm gate at the end of a function that uses external I2C bus. 
+	// It works by by checking if the current state of I2C Comms (class variable)
+	// matches the starting state (argument to this function). If they do not match (XOR), 
+	// and it was on at the start, then turn on. Otherwise, turn off.
+	
+	if ((initStateI2C == !externalI2COn) && initStateI2C) {
+		switchExternalI2C(ON);
+	} else {
+		switchExternalI2C(OFF);
+	}
 }
 
 void Margay::addDataPoint(String (*update)(void)) //Reads new data and writes data to SD
@@ -829,9 +847,22 @@ void Margay::addDataPoint(String (*update)(void)) //Reads new data and writes da
 	String data = "";
 	if(Model >= MODEL_2v0) EnviroSense.begin(0x77); //Re-initialize BME280  //FIX??
 	// Serial.println("Called Update"); //DEBUG!
-	externalI2C(ON);
-	data = (*update)(); //Run external update function
-	externalI2C(OFF);
+	
+	bool initialStateI2C = digitalRead(I2C_SW);
+
+	switchExternalI2C(ON);
+	data = (*update)(); //Run external update function	
+	switchExternalI2C(OFF);
+
+	// make sure I2C Bus is returned to initial state
+	closeFarmGateI2C(initialStateI2C);
+
+	_addDataPoint(data);
+
+}
+
+void Margay::_addDataPoint(String data) 
+{
 	// Serial.println("Request OB Vals"); //DEBUG!
 	// Briefly flash an LED to show that data are being logged
 	// without needing to waste extra time/power with a delay.

--- a/src/Margay.cpp
+++ b/src/Margay.cpp
@@ -196,7 +196,7 @@ int Margay::begin(uint8_t *Vals, uint8_t numVals, String header_)
 	// NumADR_OB = 2; //DEBUG!
 	RTC.begin(); //Initalize RTC
 	RTC.clearAlarm(); //
-	initADC();
+	initADC(18);
 	EnviroSense.begin(0x77); //Initalize onboard temp/pressure/RH sensor (BME280)
 
 
@@ -507,6 +507,14 @@ void Margay::batTest()
 	Serial.print(getBatPer());
 	Serial.println("%");
 }
+
+void Margay::initADC(uint8_t desiredResolution) 
+{
+	// Serial.print("ADC should be on"); // DEBUG
+	adc.Begin(I2C_ADR_OB[1]); //Initalize external ADC
+	adc.SetResolution(desiredResolution);
+}
+
 void Margay::powerTest()
 {
 	int Error = 0;
@@ -949,12 +957,6 @@ void Margay::dateTimeSD(uint16_t* date, uint16_t* time)
 
 	// return time using FAT_TIME macro to format fields
 	*time = FAT_TIME(selfPointer->RTC.getValue(3), selfPointer->RTC.getValue(4), selfPointer->RTC.getValue(5));
-}
-
-void Margay::initADC() 
-{
-	adc.Begin(I2C_ADR_OB[1]); //Initalize external ADC
-	adc.SetResolution(18);
 }
 
 void Margay::dateTimeSD_Glob(uint16_t* date, uint16_t* time) {selfPointer->dateTimeSD(date, time);}  //Fix dumb name!

--- a/src/Margay.h
+++ b/src/Margay.h
@@ -94,6 +94,7 @@ class Margay
 		void resetWDT();
 		void powerOB(bool State);
 		void powerAux(bool State);
+		void initADC();
 
 		//Pin definitions
 		int SD_CS = 4;

--- a/src/Margay.h
+++ b/src/Margay.h
@@ -135,7 +135,7 @@ class Margay
 		static Margay* selfPointer;
     static void dateTimeSD(uint16_t* date, uint16_t* time);
 		void dateTimeSD_Glob(uint16_t* date, uint16_t* time);
-    void externalI2C(bool state);
+	    void switchExternalI2C();
 		void sleepNow();
 		void turnOffSDcard();
 		void turnOnSDcard();

--- a/src/Margay.h
+++ b/src/Margay.h
@@ -150,7 +150,7 @@ class Margay
 		void extIntCounter();
 		int freeMemory(); //DEBUG!
 		void _addDataPoint(String data);
-		void closeFarmGateI2C(bool initStateI2C);
+		void farmGateI2C(bool initialStateExternalI2C);
 
 		DS3231_Logger RTC;
 		MCP3421 adc;

--- a/src/Margay.h
+++ b/src/Margay.h
@@ -91,10 +91,10 @@ class Margay
 		float getBatVoltage();
 		float getBatPer();
 
+		void initADC(uint8_t desiredResolution);
 		void resetWDT();
 		void powerOB(bool State);
 		void powerAux(bool State);
-		void initADC();
 
 		//Pin definitions
 		int SD_CS = 4;
@@ -135,7 +135,7 @@ class Margay
 		static Margay* selfPointer;
     static void dateTimeSD(uint16_t* date, uint16_t* time);
 		void dateTimeSD_Glob(uint16_t* date, uint16_t* time);
-	    void switchExternalI2C();
+	    void switchExternalI2C(bool desiredState);
 		void sleepNow();
 		void turnOffSDcard();
 		void turnOnSDcard();
@@ -149,6 +149,8 @@ class Margay
 		void enviroStats();
 		void extIntCounter();
 		int freeMemory(); //DEBUG!
+		void _addDataPoint(String data);
+		void closeFarmGateI2C(bool initStateI2C);
 
 		DS3231_Logger RTC;
 		MCP3421 adc;
@@ -190,6 +192,7 @@ class Margay
 		char FileNameC[11]; //Used for file handling
 		char FileNameTestC[11]; //Used for file handling
 		bool SD_Init = false;
+		bool externalI2COn = false;
 		SdFat SD;
 		byte  keep_SPCR;
 		byte keep_ADCSRA;


### PR DESCRIPTION
This change solves a problem with logging from the onboard ATC. The onboard ATC allows readings for analog voltage up to 18 bits of precision, but the typical `Margay::run()` method cannot access values from this device. 

This is because the ATC actually communicates with I2C, and so external sensors (which are typically read from I2C) might have address clashes. `Margay::run()` solves this by turning the external I2C bus on, reading data, then turning it off, but we want to also read from the internal I2C in the same breath! 

Thus, we have now added a switch to the `Margay::getVoltage()` method to test if the external I2C bus is on, and if it is, turn it off, take a reading from the ADC, then turn external I2C back on again. 

Should close #23 